### PR TITLE
Update executable prefix from nr- to nri-.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.4.0 (2019-11-18)
+### Changed
+- Renamed the integration executable from nr-cassandra to nri-cassandra in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.
 ## 2.3.0 (2019-11-15)
 - Upgraded to SDK v3.5.0. This version provides improvements for jmx support and also better error handling.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.10 as builder-cassandra
-RUN go get -d github.com/newrelic/nri-cassandra/... && \
-    cd /go/src/github.com/newrelic/nri-cassandra && \
+COPY . /go/src/github.com/newrelic/nri-cassandra/
+RUN cd /go/src/github.com/newrelic/nri-cassandra && \
     make && \
-    strip ./bin/nr-cassandra
+    strip ./bin/nri-cassandra
 
 FROM maven:3-jdk-11 as builder-jmx
 RUN git clone https://github.com/newrelic/nrjmx && \
@@ -13,7 +13,7 @@ FROM newrelic/infrastructure:latest
 ENV NRIA_IS_FORWARD_ONLY true
 ENV NRIA_K8S_INTEGRATION true
 
-COPY --from=builder-cassandra /go/src/github.com/newrelic/nri-cassandra/bin/nr-cassandra /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nr-cassandra
+COPY --from=builder-cassandra /go/src/github.com/newrelic/nri-cassandra/bin/nri-cassandra /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nri-cassandra
 COPY --from=builder-cassandra /go/src/github.com/newrelic/nri-cassandra/cassandra-definition.yml /nri-sidecar/newrelic-infra/newrelic-integrations/definition.yaml
 COPY --from=builder-jmx /nrjmx/bin /usr/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INTEGRATION     := cassandra
-BINARY_NAME      = nr-$(INTEGRATION)
+BINARY_NAME      = nri-$(INTEGRATION)
 SRC_DIR          = ./src/
 VALIDATE_DEPS    = golang.org/x/lint/golint
 TEST_DEPS        = github.com/axw/gocov/gocov github.com/AlekSi/gocov-xml

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is required to configure the JMX user and password. Follow the steps in [Enab
 ## Installation
 * Download an archive file for the Cassandra Integration
 * Place the executables under `bin` directory and the definition file `cassandra-definition.yml` in `/var/db/newrelic-infra/newrelic-integrations`
-* Set execution permissions for the binary files `nr-cassandra` and `nrjmx` (if required)
+* Set execution permissions for the binary files `nri-cassandra` and `nrjmx` (if required)
 * Place the integration configuration file `cassandra-config.yml.sample` in `/etc/newrelic-infra/integrations.d` and update its values.
 
 ## Usage
@@ -33,13 +33,13 @@ Assuming that you have source code you can build and run the Cassandra Integrati
 ```bash
 $ make
 ```
-* The command above will execute tests for the Cassandra Integration and build an executable file called `nr-cassandra` in `bin` directory.
+* The command above will execute tests for the Cassandra Integration and build an executable file called `nri-cassandra` in `bin` directory.
 ```bash
-$ ./bin/nr-cassandra --hostname <JMX hostname> --port <JMX port> --username <username> --password <password> --config_path <path to cassandra config>
+$ ./bin/nri-cassandra --hostname <JMX hostname> --port <JMX port> --username <username> --password <password> --config_path <path to cassandra config>
 ```
-* If you want to know more about usage of `./bin/nr-cassandra` check
+* If you want to know more about usage of `./bin/nri-cassandra` check
 ```bash
-$ ./bin/nr-cassandra --help
+$ ./bin/nri-cassandra --help
 ```
 
 For managing external dependencies [govendor tool](https://github.com/kardianos/govendor) is used. It is required to lock all external dependencies to specific version (if possible) into vendor directory.

--- a/cassandra-definition.yml
+++ b/cassandra-definition.yml
@@ -6,12 +6,12 @@ os: linux
 commands:
     metrics:
         command:
-          - ./bin/nr-cassandra
+          - ./bin/nri-cassandra
           - --metrics
         interval: 30
     inventory:
         command:
-          - ./bin/nr-cassandra
+          - ./bin/nri-cassandra
           - --inventory
         interval: 60
         prefix: config/cassandra

--- a/src/cassandra.go
+++ b/src/cassandra.go
@@ -27,7 +27,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.cassandra"
-	integrationVersion = "2.1.0"
+	integrationVersion = "2.4.0"
 
 	entityRemoteType = "node"
 )

--- a/tests/integration/cassandra_test.go
+++ b/tests/integration/cassandra_test.go
@@ -30,7 +30,7 @@ var (
 
 	iVersion = "1.1.0"
 
-	defaultBinPath  = "/nr-cassandra"
+	defaultBinPath  = "/nri-cassandra"
 	defaultHostname = "cassandra"
 
 	schemaFolder = fmt.Sprintf("json-schema-files-%s", envCassandraVersion)


### PR DESCRIPTION
### Changed
- Renamed the integration executable from nr-cassandra to nri-cassandra in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.