### PR TITLE
Add REMOTE_MONITORING to k8s config sample

### DIFF
--- a/cassandra-config.yml.k8s_sample
+++ b/cassandra-config.yml.k8s_sample
@@ -18,3 +18,4 @@
           USERNAME: cassandra
           PASSWORD: cassandra
           METRICS: 1
+          REMOTE_MONITORING: true


### PR DESCRIPTION
#### Description of the changes
REMOTE_MONITORING was not set in k8s config file what made that the integration was reusing the cache file for all the instances with the same port (the port was the only attribute used as a key for the cache data). And this was causing wired metrics reports like negative rate values metrics.

#### PR Review Checklist
### Author

- [ ] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
