### PR TITLE
Update test Dockerfile to build nrjmx with gradle.

### DIFF
--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -4,13 +4,14 @@ WORKDIR /go/src/github.com/newrelic/nri-cassandra
 COPY . .
 RUN make clean compile
 
-FROM maven:3-jdk-11 as jmxbuilder
+FROM gradle:6.6.1-jdk11 as jmxbuilder
 RUN git clone https://github.com/newrelic/nrjmx.git \
     && cd nrjmx \
-    && mvn clean package -DskipTests -P \!deb,\!rpm,\!test,\!tarball
+    && gradle package
 
-FROM maven:3.6-jdk-11
+FROM gradle:6.6.1-jdk11
 COPY --from=builder /go/src/github.com/newrelic/nri-cassandra/bin /
-COPY --from=jmxbuilder /nrjmx/bin /usr/bin/
+COPY --from=jmxbuilder /home/gradle/nrjmx/bin /usr/bin/
+COPY --from=jmxbuilder /home/gradle/nrjmx/build/distributions/nrjmx-*-noarch.jar /usr/bin/nrjmx.jar
 
 CMD ["sleep", "1h"]


### PR DESCRIPTION
Since `nrjmx` switched from Maven to Gradle (in https://github.com/newrelic/nrjmx/pull/55), running `make integration-test` fails when building `nrjmx`:
```
Step 7/11 : RUN git clone https://github.com/newrelic/nrjmx.git     && cd nrjmx     && mvn clean package -DskipTests -P \!deb,\!rpm,\!test,\!tarball
 ---> Running in 74718a675ad2
Cloning into 'nrjmx'...
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.153 s
[INFO] Finished at: 2020-11-13T18:07:11Z
[INFO] ------------------------------------------------------------------------
[ERROR] The goal you specified requires a project to execute but there is no POM in this directory (/nrjmx). Please verify you invoked Maven from the correct directory. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MissingProjectException
ERROR: Service 'nri-cassandra' failed to build : The command '/bin/sh -c git clone https://github.com/newrelic/nrjmx.git     && cd nrjmx     && mvn clean package -DskipTests -P \!deb,\!rpm,\!test,\!tarball' returned a non-zero code: 1
make: *** [integration-test] Error 1
```

This PR updates the test Dockerfile to build `nrjmx` with gradle, using the Gradle docker image from Docker Hub.

It looks like the long-term solution is to overhaul the integration test pipeline by merging #59, but in the meantime, this will enable developers to run integration tests locally.