### PR TITLE
Enable JMX connections with SSL/TLS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.6.0 (TODO)
+### Changed
+- Enable JMX connections with SSL/TLS.
+
 ## 2.5.0 (2020-09-07)
 ### Changed
 - Add hinted handoff manager metrics

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ To start the integration:
 $ ./bin/nri-cassandra --hostname <JMX hostname> --port <JMX port> --username <username> --password <password> --config_path <path to cassandra config>
 ```
 
+If JMX is configured to use TLS/SSL, add options related to keystore and truststore:
+
+```bash
+$ ./bin/nri-cassandra --hostname <JMX hostname> --port <JMX port> --username <username> --password <password> --config_path <path to cassandra config> --key_store <path to keystore> --key_store_password <keystore password> --trust_store <path to truststore> --trust_store_password <truststore password>
+
+```
+
 If you want to know more about usage of `./bin/nri-cassandra`, pass the `-help` parameter:
 
 ```bash

--- a/src/cassandra.go
+++ b/src/cassandra.go
@@ -24,6 +24,10 @@ type argumentList struct {
 	Timeout             int    `default:"2000" help:"Timeout in milliseconds per single JMX query."`
 	ColumnFamiliesLimit int    `default:"20" help:"Limit on number of Cassandra Column Families."`
 	RemoteMonitoring    bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true."`
+	KeyStore            string `default:"" help:"The location for the keystore containing JMX Client's SSL certificate"`
+	KeyStorePassword    string `default:"" help:"Password for the SSL Key Store"`
+	TrustStore          string `default:"" help:"The location for the keystore containing JMX Server's SSL certificate"`
+	TrustStorePassword  string `default:"" help:"Password for the SSL Trust Store"`
 }
 
 const (
@@ -47,6 +51,11 @@ func main() {
 	var opts []jmx.Option
 	if args.Verbose {
 		opts = append(opts, jmx.WithVerbose())
+	}
+
+	if args.KeyStore != "" && args.KeyStorePassword != "" && args.TrustStore != "" && args.TrustStorePassword != "" {
+		ssl := jmx.WithSSL(args.KeyStore, args.KeyStorePassword, args.TrustStore, args.TrustStorePassword)
+		opts = append(opts, ssl)
 	}
 
 	fatalIfErr(jmx.Open(args.Hostname, strconv.Itoa(args.Port), args.Username, args.Password, opts...))

--- a/src/cassandra.go
+++ b/src/cassandra.go
@@ -32,7 +32,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.cassandra"
-	integrationVersion = "2.5.0"
+	integrationVersion = "2.6.0"
 
 	entityRemoteType = "node"
 )


### PR DESCRIPTION
Fixes #65.

This PR adds configuration options so that nri-cassandra can connect to Cassandra JMX endpoints that use SSL/TLS encryption..

It works just like the [nri-kafka integration](https://github.com/newrelic/nri-kafka), where you must pass in 4 options to turn on SSL:

1. key_store
2. key_store_password
3. trust_store
4. trust_store_password

See https://github.com/newrelic/nri-kafka/pull/53

I'm undecided about whether the addition of configuration options deserves integration tests. Most of the current integration tests that exercise different configuration options are all being skipped right now.

A true end-to-end test would set up a Cassandra container configured to use SSL for JMX and then call it successfully with nri-cassandra. Yet, setting up all that infrastructure just to test SSL options seems a bit excessive.

The included tests do confirm that:

1. Incomplete SSL configuration is ignored, as expected.
2. Complete SSL configuration results in passing SSL options to nrjmx.

If you think that the included tests don't add a lot of value, I'm happy to delete them altogether.