### PR TITLE
Cassandra Logging Template File

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -49,6 +49,8 @@ nfpms:
     contents:
       - src: "cassandra-config.yml.sample"
         dst: "/etc/newrelic-infra/integrations.d/cassandra-config.yml.sample"
+      - src: "cassandra-log.yml.example"
+        dst: "/etc/newrelic-infra/logging.d/cassandra-log.yml.example"
       - src: "CHANGELOG.md"
         dst: "/usr/share/doc/nri-cassandra/CHANGELOG.md"
       - src: "README.md"

--- a/cassandra-log.yml.example
+++ b/cassandra-log.yml.example
@@ -1,0 +1,16 @@
+###############################################################################
+# This sample file will forward cassandra error logs to NR once               #
+#   it is renamed to cassandra-log.yml                                        #
+# On Linux systems no restart is needed after it is renamed                   #
+# Source: memcached error log file                                            #
+# Available customization parameters: attributes, max_line_kb, pattern        #
+###############################################################################
+logs:
+  - name: "cassandra-system-log"
+    file: /var/log/cassandra/system.log
+    attributes:
+      logtype: cassandra
+  - name: "cassandra-gc-log"
+    file: /var/log/cassandra/gc.log.*.current
+    attributes:
+      logtype: cassandra-gc


### PR DESCRIPTION
Initial commit of a Cassandra logging template file. By renaming this file, customers can automatically send parsed Cassandra logs to NR.