### PR TITLE
Add log when hitting the limit column families

### DIFF
--- a/src/metrics.go
+++ b/src/metrics.go
@@ -63,6 +63,8 @@ func getMetrics(client *gojmx.Client) (map[string]interface{}, map[string]map[st
 						if len(visitedColumnFamilies) < args.ColumnFamiliesLimit {
 							visitedColumnFamilies[eventkey] = struct{}{}
 						} else {
+							log.Warn("Visited column families limit reached. Current limit set to %d",
+								args.ColumnFamiliesLimit)
 							continue
 						}
 					}


### PR DESCRIPTION
Closes https://github.com/newrelic/nri-cassandra/issues/94.

Add a warning log when we reach the limit of visited column families.