### PR TITLE
log internal query stats

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -65,14 +65,14 @@ nfpms:
       deb:
         dependencies:
           - newrelic-infra (>= 1.20.0)
-          - nrjmx (>= 2.0.2)
+          - nrjmx (>= 2.2.2)
       rpm:
         file_name_template: "{{ .ProjectName }}-{{ .Version }}-1.{{ .Arch }}"
         replacements:
           amd64: x86_64
         dependencies:
           - newrelic-infra >= 1.20.0
-          - nrjmx >= 2.0.2
+          - nrjmx >= 2.2.2
 
      # Formats to be generated.
     formats:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/google/uuid v1.3.0
 	github.com/newrelic/infra-integrations-sdk v3.7.3+incompatible
-	github.com/newrelic/nrjmx/gojmx v0.0.0-20220824072913-0b9ce66cfbe9
+	github.com/newrelic/nrjmx/gojmx v0.0.0-20220831103627-56d00601006c
 	github.com/stretchr/testify v1.8.0
 	github.com/testcontainers/testcontainers-go v0.12.0
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,8 @@ github.com/newrelic/infra-integrations-sdk v3.7.3+incompatible h1:+o/MxTzFsC3BRV
 github.com/newrelic/infra-integrations-sdk v3.7.3+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
 github.com/newrelic/nrjmx/gojmx v0.0.0-20220824072913-0b9ce66cfbe9 h1:9Wr6q7GxCfe12o2yaasZt1RGMd2GlLWsCD6N/rQuKxQ=
 github.com/newrelic/nrjmx/gojmx v0.0.0-20220824072913-0b9ce66cfbe9/go.mod h1:zd01rBtry4cfiVBXpUhBeEjolk86vMczWd/d7QQHGK8=
+github.com/newrelic/nrjmx/gojmx v0.0.0-20220831103627-56d00601006c h1:B6Fj3lqF+NnztRe+DMXRJsp+gKRKhznmQd5qzQAEP/U=
+github.com/newrelic/nrjmx/gojmx v0.0.0-20220831103627-56d00601006c/go.mod h1:zd01rBtry4cfiVBXpUhBeEjolk86vMczWd/d7QQHGK8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/src/cassandra.go
+++ b/src/cassandra.go
@@ -140,12 +140,11 @@ func collectMetricsEachInterval(i *integration.Integration, jmxClient *gojmx.Cli
 // collectMetrics will gather all the required metrics from the JMX endpoint and attach them the the sdk integration.
 func collectMetrics(i *integration.Integration, jmxClient *gojmx.Client) error {
 	// For troubleshooting purpose, if enabled, integration will log internal query stats.
-	defer func() {
-		if !args.EnableInternalStats {
-			return
+		if args.EnableInternalStats {
+	    		defer func() {
+		        		logInternalStats(jmxClient)
+	    		}()
 		}
-		logInternalStats(jmxClient)
-	}()
 
 	e, err := entity(i)
 	if err != nil {

--- a/src/cassandra.go
+++ b/src/cassandra.go
@@ -140,11 +140,11 @@ func collectMetricsEachInterval(i *integration.Integration, jmxClient *gojmx.Cli
 // collectMetrics will gather all the required metrics from the JMX endpoint and attach them the the sdk integration.
 func collectMetrics(i *integration.Integration, jmxClient *gojmx.Client) error {
 	// For troubleshooting purpose, if enabled, integration will log internal query stats.
-		if args.EnableInternalStats {
-	    		defer func() {
-		        		logInternalStats(jmxClient)
-	    		}()
-		}
+	if args.EnableInternalStats {
+		defer func() {
+			logInternalStats(jmxClient)
+		}()
+	}
 
 	e, err := entity(i)
 	if err != nil {

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.18 as builder
 
 ARG CGO_ENABLED=0
-ARG NRJMX_VERSION=2.2.1
+ARG NRJMX_VERSION=2.2.2
 
 WORKDIR /go/src/github.com/newrelic/nri-cassandra
 COPY . .


### PR DESCRIPTION
Adding ENABLE_INTERNAL_STATS configuration option. When this option is enabled and the integration is running in verbose mode, after each collection, it will output in the logs nrjmx internal query statistics. This will be handy when troubleshooting performance issues.