### PR TITLE
chore(golang): pin golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder-cassandra
+FROM golang:1.20.6 as builder-cassandra
 COPY . /go/src/github.com/newrelic/nri-cassandra/
 RUN cd /go/src/github.com/newrelic/nri-cassandra && \
     make && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.20.6
 
 ARG GH_VERSION='2.23.0'
 

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.20.6 as builder
 
 ARG CGO_ENABLED=0
 ARG NRJMX_VERSION=2.3.2


### PR DESCRIPTION
We decided to pin golang version and [automerge them](https://github.com/newrelic/coreint-automation/commit/398ade41391d36da64320e123d832566d201601b)