### PR TITLE
Fix native transport metrics

### DIFF
--- a/src/metric_definitions.go
+++ b/src/metric_definitions.go
@@ -1033,13 +1033,13 @@ var metricDefinitions = []Query{
 	{
 		MBean: "org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=ActiveTasks",
 		Attributes: []Attribute{
-			{MBeanAttribute: "Count", Alias: "db.threadpool.nativeTransportRequestActiveTasks", MetricType: metric.GAUGE},
+			{MBeanAttribute: "Value", Alias: "db.threadpool.nativeTransportRequestActiveTasks", MetricType: metric.GAUGE},
 		},
 	},
 	{
 		MBean: "org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=CompletedTasks",
 		Attributes: []Attribute{
-			{MBeanAttribute: "Count", Alias: "db.threadpool.nativeTransportRequestCompletedTasks", MetricType: metric.GAUGE},
+			{MBeanAttribute: "Value", Alias: "db.threadpool.nativeTransportRequestCompletedTasks", MetricType: metric.GAUGE},
 		},
 	},
 	{
@@ -1051,7 +1051,7 @@ var metricDefinitions = []Query{
 	{
 		MBean: "org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=PendingTasks",
 		Attributes: []Attribute{
-			{MBeanAttribute: "Count", Alias: "db.threadpool.nativeTransportRequestPendingTasks", MetricType: metric.GAUGE},
+			{MBeanAttribute: "Value", Alias: "db.threadpool.nativeTransportRequestPendingTasks", MetricType: metric.GAUGE},
 		},
 	},
 	{


### PR DESCRIPTION
The native transport metrics MBeans for ActiveTasks, CompletedTasks, and PendingTasks have a attribute named "Value" instead of "Count". This change updates the MBeanAttribute names to match the actual attribute names. The NTR metrics were added in #117.

`Counter`-type threadpool metrics use the attribute name "Count", while `Gauge<Integer>`-type threadpool metrics use the attribute name "Value":
* https://github.com/apache/cassandra/blob/cassandra-4.0/src/java/org/apache/cassandra/metrics/ThreadPoolMetrics.java#L44-L66

See the JMX test data from apache/cassandra. Note the file is too large to view in GitHub.
https://github.com/apache/cassandra/blob/trunk/test/data/jmxdump/cassandra-4.0-jmx.yaml

From a local Cassandra checkout:
```
❯ grep -A2 ',path=transport,scope=Native-Transport-Requests' test/data/jmxdump/cassandra-4.0-jmx.yaml
org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=ActiveTasks:
  attributes:
  - {access: read-only, name: Value, type: java.lang.Object}
--
org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=CompletedTasks:
  attributes:
  - {access: read-only, name: Value, type: java.lang.Object}
--
org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=CurrentlyBlockedTasks:
  attributes:
  - {access: read-only, name: Count, type: long}
--
org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=MaxPoolSize:
  attributes:
  - {access: read-only, name: Value, type: java.lang.Object}
--
org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=MaxTasksQueued:
  attributes:
  - {access: read-only, name: Value, type: java.lang.Object}
--
org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=PendingTasks:
  attributes:
  - {access: read-only, name: Value, type: java.lang.Object}
--
org.apache.cassandra.metrics:type=ThreadPools,path=transport,scope=Native-Transport-Requests,name=TotalBlockedTasks:
  attributes:
  - {access: read-only, name: Count, type: long}
```