### PR TITLE
fix: use the proper publish-schema on pre-release action

### DIFF
--- a/.github/workflows/on_prerelease.yaml
+++ b/.github/workflows/on_prerelease.yaml
@@ -14,4 +14,5 @@ jobs:
       integration: "cassandra"
       windows_goarch_matrix: '["amd64"]' # 386 is not supported in jmx integrations
       windows_download_nrjmx: true
+      publish_schema: "ohi-jmx"
     secrets: inherit


### PR DESCRIPTION
This seems to be the cause of the [latest pre-release failure](https://github.com/newrelic/nri-cassandra/actions/runs/7989919227/job/21818541489).