### PR TITLE
fix(ci/cd): the package is exe type

### DIFF
--- a/.github/workflows/on_prerelease.yaml
+++ b/.github/workflows/on_prerelease.yaml
@@ -15,4 +15,5 @@ jobs:
       windows_goarch_matrix: '["amd64"]' # 386 is not supported in jmx integrations
       windows_download_nrjmx: true
       publish_schema: "ohi-jmx"
+      win_package_type: exe
     secrets: inherit


### PR DESCRIPTION
This is needed to avoid:
> :warning: Couldn’t fetch latest version from http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/windows/integrations/nri-cassandra/nri-cassandra-amd64.msi[,](http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/windows/integrations/nri-cassandra/nri-cassandra-amd64.msi,) skipping test