### PR TITLE
[NR-286408] fix(test): update docker compose command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 integration-test:
 	@echo "=== $(INTEGRATION) === [ test ]: running integration tests..."
 	@go clean -testcache
-	@go test -v -timeout 600s -tags=integration ./tests/integration/. || (ret=$$?; docker-compose -f tests/integration/docker-compose.yml down && exit $$ret)
+	@go test -v -timeout 600s -tags=integration ./tests/integration/. || (ret=$$?; docker compose -f tests/integration/docker-compose.yml down && exit $$ret)
 
 install: compile
 	@echo "=== $(INTEGRATION) === [ install ]: installing bin/$(BINARY_NAME)..."

--- a/tests/integration/testutils/test_utils.go
+++ b/tests/integration/testutils/test_utils.go
@@ -198,8 +198,8 @@ func isComposeReady(cxt context.Context) bool {
 func ConfigureCassandraDockerCompose(ctx context.Context) error {
 	composeFilePaths := filepath.Join(GetIntegrationTestsPath(), "docker-compose.yml")
 
-	args := []string{"-f", composeFilePaths, "up", "-d", "--build"}
-	cmd := exec.CommandContext(ctx, "docker-compose", args...)
+	args := []string{"compose", "-f", composeFilePaths, "up", "-d", "--build"}
+	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("EXTRA_JVM_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=%s -Dcom.sun.management.jmxremote=true", Hostname))
 
 	cmd.Stderr = os.Stderr
@@ -207,11 +207,11 @@ func ConfigureCassandraDockerCompose(ctx context.Context) error {
 
 	err := cmd.Start()
 	if err != nil {
-		return fmt.Errorf("failed to run docker-compose: error: %w", err)
+		return fmt.Errorf("failed to run docker compose: error: %w", err)
 	}
 
 	if !isComposeReady(ctx) {
-		return fmt.Errorf("failed to run docker-compose: it has not reached a ready state")
+		return fmt.Errorf("failed to run docker compose: it has not reached a ready state")
 	}
 
 	return nil
@@ -221,8 +221,8 @@ func ConfigureCassandraDockerCompose(ctx context.Context) error {
 func ConfigureSSLCassandraDockerCompose(ctx context.Context) error {
 	composeFilePaths := filepath.Join(GetIntegrationTestsPath(), "docker-compose.yml")
 
-	args := []string{"-f", composeFilePaths, "up", "-d", "--build"}
-	cmd := exec.CommandContext(ctx, "docker-compose", args...)
+	args := []string{"compose", "-f", composeFilePaths, "up", "-d", "--build"}
+	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Env = append(os.Environ(), "EXTRA_JVM_OPTS= -Dcom.sun.management.jmxremote.authenticate=true "+
 		fmt.Sprintf("-Djava.rmi.server.hostname=%s ", Hostname)+
 		"-Dcom.sun.management.jmxremote.ssl=true "+
@@ -240,11 +240,11 @@ func ConfigureSSLCassandraDockerCompose(ctx context.Context) error {
 
 	err := cmd.Start()
 	if err != nil {
-		return fmt.Errorf("failed to run docker-compose: error: %w", err)
+		return fmt.Errorf("failed to run docker compose: error: %w", err)
 	}
 
 	if !isComposeReady(ctx) {
-		return fmt.Errorf("failed to run docker-compose: it has not reached a ready state")
+		return fmt.Errorf("failed to run docker compose: it has not reached a ready state")
 	}
 
 	return nil


### PR DESCRIPTION
We run into [this issue](https://github.com/docker/compose/issues/11693), basically the `docker-compose` v1 is EOL, and we need to move to `docker compose` (wit a space).