### PR TITLE
chore: update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-## v2.13.7 - 2024-06-26
-
-### ⛓️ Dependencies
-- Updated golang version to v1.22.4
-- Updated github.com/newrelic/nrjmx/gojmx digest
-
 ## v2.13.6 - 2024-05-08
 
 ### ⛓️ Dependencies


### PR DESCRIPTION
This PR removes the latest release from the change-log in order to delete it completely. Right after merging it, the pre-release will be removed in order that release-toolkit is able to generate it again.