### PR TITLE
 Upgrade integrations SDK (NR-302384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### enhancements
+
+- Upgrade integrations SDK so the interval is variable and allows intervals up to 5 minutes
+
 ## v2.13.10 - 2024-09-11
 
 ### ⛓️ Dependencies

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 require (
 	github.com/apache/thrift v0.18.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/newrelic/nri-cassandra
 go 1.23.1
 
 require (
-	github.com/newrelic/infra-integrations-sdk v3.8.2+incompatible
+	github.com/newrelic/infra-integrations-sdk/v3 v3.9.1
 	github.com/newrelic/nrjmx/gojmx v0.0.0-20240305121005-9fddfa34e08e
 	github.com/stretchr/testify v1.9.0
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -45,14 +45,8 @@ github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 h1:rzf0wL0CHVc8CEsgyygG0
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/newrelic/infra-integrations-sdk v3.8.0+incompatible h1:QvwHLsgHyGw4ZULOSnnWQnVPE744K1eda+2XLp2eHtg=
-github.com/newrelic/infra-integrations-sdk v3.8.0+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
-github.com/newrelic/infra-integrations-sdk v3.8.2+incompatible h1:Ktcm1aPAl7CW3o+FXAIKJ+jygWVXDXaUIWFyf2CXQTk=
-github.com/newrelic/infra-integrations-sdk v3.8.2+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
 github.com/newrelic/infra-integrations-sdk/v3 v3.9.1 h1:dCtVLsYNHWTQ5aAlAaHroomOUlqxlGTrdi6XTlvBDfI=
 github.com/newrelic/infra-integrations-sdk/v3 v3.9.1/go.mod h1:yPeidhcq9Cla0QDquGXH0KqvS2k9xtetFOD7aLA0Z8M=
-github.com/newrelic/nrjmx/gojmx v0.0.0-20230714122532-90d44704c70c h1:UC77tt3fDB0jSsduXxrOIjxe77ezfnqeXCYM96l9usU=
-github.com/newrelic/nrjmx/gojmx v0.0.0-20230714122532-90d44704c70c/go.mod h1:tDD9KR/voGBWOlqnTdXfo+oDVXhg2HD0KrYwBrgd04s=
 github.com/newrelic/nrjmx/gojmx v0.0.0-20240305121005-9fddfa34e08e h1:ZYdlZuIA9RZjJKkYA+PvfZ1QuRXsU9uIZOQt7wSUr7s=
 github.com/newrelic/nrjmx/gojmx v0.0.0-20240305121005-9fddfa34e08e/go.mod h1:cevS+iKLxJJ+gQY0RpHIJSoEZwJMTU3j/1tI50ztq1c=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -73,8 +67,6 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/testcontainers/testcontainers-go v0.12.0 h1:SK0NryGHIx7aifF6YqReORL18aGAA4bsDPtikDVCEyg=

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/newrelic/infra-integrations-sdk v3.8.0+incompatible h1:QvwHLsgHyGw4ZU
 github.com/newrelic/infra-integrations-sdk v3.8.0+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
 github.com/newrelic/infra-integrations-sdk v3.8.2+incompatible h1:Ktcm1aPAl7CW3o+FXAIKJ+jygWVXDXaUIWFyf2CXQTk=
 github.com/newrelic/infra-integrations-sdk v3.8.2+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
+github.com/newrelic/infra-integrations-sdk/v3 v3.9.1 h1:dCtVLsYNHWTQ5aAlAaHroomOUlqxlGTrdi6XTlvBDfI=
+github.com/newrelic/infra-integrations-sdk/v3 v3.9.1/go.mod h1:yPeidhcq9Cla0QDquGXH0KqvS2k9xtetFOD7aLA0Z8M=
 github.com/newrelic/nrjmx/gojmx v0.0.0-20230714122532-90d44704c70c h1:UC77tt3fDB0jSsduXxrOIjxe77ezfnqeXCYM96l9usU=
 github.com/newrelic/nrjmx/gojmx v0.0.0-20230714122532-90d44704c70c/go.mod h1:tDD9KR/voGBWOlqnTdXfo+oDVXhg2HD0KrYwBrgd04s=
 github.com/newrelic/nrjmx/gojmx v0.0.0-20240305121005-9fddfa34e08e h1:ZYdlZuIA9RZjJKkYA+PvfZ1QuRXsU9uIZOQt7wSUr7s=

--- a/src/cassandra.go
+++ b/src/cassandra.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"time"
 
-	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
-	"github.com/newrelic/infra-integrations-sdk/data/attribute"
-	"github.com/newrelic/infra-integrations-sdk/data/metric"
-	"github.com/newrelic/infra-integrations-sdk/integration"
-	"github.com/newrelic/infra-integrations-sdk/log"
+	sdkArgs "github.com/newrelic/infra-integrations-sdk/v3/args"
+	"github.com/newrelic/infra-integrations-sdk/v3/data/attribute"
+	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
+	"github.com/newrelic/infra-integrations-sdk/v3/integration"
+	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"github.com/newrelic/nrjmx/gojmx"
 )
 

--- a/src/cassandra.go
+++ b/src/cassandra.go
@@ -11,15 +11,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/newrelic/nrjmx/gojmx"
-
-	"github.com/newrelic/infra-integrations-sdk/data/attribute"
-
 	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
+	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/newrelic/infra-integrations-sdk/log"
-	"github.com/newrelic/infra-integrations-sdk/persist"
+	"github.com/newrelic/nrjmx/gojmx"
 )
 
 type argumentList struct {
@@ -60,7 +57,7 @@ var (
 )
 
 func main() {
-	i, err := createIntegration()
+	i, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
 	fatalIfErr(err)
 
 	if args.ShowVersion {
@@ -203,21 +200,6 @@ func metricSet(e *integration.Entity, eventType, hostname string, port int, remo
 		eventType,
 		attribute.Attr("port", strconv.Itoa(port)),
 	)
-}
-
-func createIntegration() (*integration.Integration, error) {
-	cachePath := os.Getenv("NRIA_CACHE_PATH")
-	if cachePath == "" {
-		return integration.New(integrationName, integrationVersion, integration.Args(&args))
-	}
-
-	l := log.NewStdErr(args.Verbose)
-	s, err := persist.NewFileStore(cachePath, l, persist.DefaultTTL)
-	if err != nil {
-		return nil, err
-	}
-
-	return integration.New(integrationName, integrationVersion, integration.Args(&args), integration.Storer(s), integration.Logger(l))
 }
 
 // getJMXConfig will use the integration args to prepare the JMXConfig for the JMXClient.

--- a/src/cassandra_test.go
+++ b/src/cassandra_test.go
@@ -8,9 +8,9 @@ package main
 import (
 	"testing"
 
-	"github.com/newrelic/infra-integrations-sdk/data/inventory"
-	"github.com/newrelic/infra-integrations-sdk/data/metric"
-	"github.com/newrelic/infra-integrations-sdk/persist"
+	"github.com/newrelic/infra-integrations-sdk/v3/data/inventory"
+	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
+	"github.com/newrelic/infra-integrations-sdk/v3/persist"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/filtering_test.go
+++ b/src/filtering_test.go
@@ -8,7 +8,7 @@ package main
 import (
 	"testing"
 
-	"github.com/newrelic/infra-integrations-sdk/data/metric"
+	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/src/inventory.go
+++ b/src/inventory.go
@@ -7,13 +7,13 @@ package main
 
 import (
 	"errors"
-	"github.com/newrelic/infra-integrations-sdk/log"
+	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"io/ioutil"
 	"regexp"
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/newrelic/infra-integrations-sdk/data/inventory"
+	"github.com/newrelic/infra-integrations-sdk/v3/data/inventory"
 )
 
 var (

--- a/src/inventory.go
+++ b/src/inventory.go
@@ -7,9 +7,10 @@ package main
 
 import (
 	"errors"
-	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"io/ioutil"
 	"regexp"
+
+	"github.com/newrelic/infra-integrations-sdk/v3/log"
 
 	"gopkg.in/yaml.v2"
 

--- a/src/metric_definitions.go
+++ b/src/metric_definitions.go
@@ -8,7 +8,7 @@ package main
 import (
 	"reflect"
 
-	"github.com/newrelic/infra-integrations-sdk/data/metric"
+	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
 )
 
 // Definitions struct will contain the metrics that have to be collected.

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/newrelic/nrjmx/gojmx"
 
-	"github.com/newrelic/infra-integrations-sdk/data/metric"
-	"github.com/newrelic/infra-integrations-sdk/log"
+	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
+	"github.com/newrelic/infra-integrations-sdk/v3/log"
 )
 
 var (

--- a/src/query.go
+++ b/src/query.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/newrelic/infra-integrations-sdk/data/metric"
+import "github.com/newrelic/infra-integrations-sdk/v3/data/metric"
 
 // Query defines a JMX query that has to be performed. Multiple JMX attributes can be received through a single Query.
 // Each JMX Attribute maps to a single NR metric. We set an Alias to attribute to define the name of the metric in NR.

--- a/tests/integration/cassandra_long_running_test.go
+++ b/tests/integration/cassandra_long_running_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/newrelic/infra-integrations-sdk/log"
+	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"github.com/newrelic/nri-cassandra/tests/integration/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Upgrade the integrations SDK removes the need to implement a storer in all integrations and rises the maximum interval to 5 minutes (if needed)