### PR TITLE
chore(deps): upgrade golang.org/x/* to fix security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Security
+- Upgraded `golang.org/x/crypto` from v0.52.0 to v0.54.0 to fix [CVE-2026-39829](https://www.cve.org/CVERecord?id=CVE-2026-39829) (RSA/DSA key size DoS), [CVE-2026-39830](https://www.cve.org/CVERecord?id=CVE-2026-39830) (SSH goroutine/resource leak), [CVE-2026-39831](https://www.cve.org/CVERecord?id=CVE-2026-39831) (FIDO/U2F User Presence bypass), [CVE-2026-39834](https://www.cve.org/CVERecord?id=CVE-2026-39834) (SSH integer overflow infinite loop), [CVE-2026-42508](https://www.cve.org/CVERecord?id=CVE-2026-42508) (SSH CA revocation bypass), [CVE-2026-46595](https://www.cve.org/CVERecord?id=CVE-2026-46595) (SSH authorization bypass), [CVE-2026-46598](https://www.cve.org/CVERecord?id=CVE-2026-46598) (ed25519 panic)
+- Upgraded `golang.org/x/sys` from v0.45.0 to v0.47.0
+
 ## v2.21.1 - 2026-07-22
 
 ### ⛓️ Dependencies

--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,7 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	golang.org/x/crypto v0.54.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -126,10 +126,10 @@ go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWv
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
-golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
-golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
## Summary
- Upgraded `golang.org/x/crypto` v0.52.0 → v0.54.0
- Upgraded `golang.org/x/sys` v0.45.0 → v0.47.0

## Reason
Grype security scan (#1571) failed due to medium+ severity CVEs in `golang.org/x/crypto v0.52.0` and `golang.org/x/sys v0.45.0`. These are transitive dependencies pulled in via `nrjmx/gojmx` → `apache/thrift`."